### PR TITLE
修正(commands): JSTタイムゾーンを使用して時間を取得するように変更

### DIFF
--- a/commands/lunch.go
+++ b/commands/lunch.go
@@ -74,15 +74,19 @@ func (c *LunchCommand) Execute(cmd slack.SlashCommand) error {
 		return err
 	}
 
+	// Get JST time
+	jst, _ := time.LoadLocation("Asia/Tokyo")
+	now := time.Now().In(jst)
+
 	// Save last lunch date
-	userPresence["last_lunch_date"] = time.Now().Format(time.RFC3339)
+	userPresence["last_lunch_date"] = now.Format(time.RFC3339)
 	if err := c.redisClient.SetUserPresence(uid, userPresence); err != nil {
 		slog.Error("Failed to set user presence", slog.Any("error", err))
 		return err
 	}
 
 	// Response message
-	returnTime := time.Now().Add(1 * time.Hour).Format("15:04")
+	returnTime := now.Add(1 * time.Hour).Format("15:04")
 	_, err = c.client.PostEphemeral(channelID, uid, slack.MsgOptionText(fmt.Sprintf("行ってらっしゃい!!1 %sに自動で解除します", returnTime), false))
 	if err != nil {
 		slog.Error("Failed to post ephemeral message", slog.Any("error", err))

--- a/commands/start.go
+++ b/commands/start.go
@@ -44,7 +44,9 @@ func (c *StartCommand) Execute(cmd slack.SlashCommand) error {
 	}
 
 	// Set today's begin time
-	userPresence["today_begin"] = time.Now().Format(time.RFC3339)
+	jst, _ := time.LoadLocation("Asia/Tokyo")
+	now := time.Now().In(jst)
+	userPresence["today_begin"] = now.Format(time.RFC3339)
 	if err := c.redisClient.SetUserPresence(uid, userPresence); err != nil {
 		slog.Error("Failed to set user presence", slog.Any("error", err))
 		return err

--- a/store/redis.go
+++ b/store/redis.go
@@ -59,8 +59,10 @@ func (r *RedisClient) GetUserPresence(uid string) (map[string]interface{}, error
 	key := uid + "-store"
 	val, err := r.client.Get(ctx, key).Result()
 	if err == redis.Nil {
+		jst, _ := time.LoadLocation("Asia/Tokyo")
+		now := time.Now().In(jst)
 		return map[string]interface{}{
-			"last_active_start_time": time.Now().Format(time.RFC3339),
+			"last_active_start_time": now.Format(time.RFC3339),
 		}, nil
 	} else if err != nil {
 		return nil, err


### PR DESCRIPTION
なぜ: 一貫した時間管理のため、全ての時間操作をJSTに統一するため